### PR TITLE
fix(preview-server): bump zod to v4 to prevent fumadocs postinstall crash

### DIFF
--- a/packages/preview-server/package.json
+++ b/packages/preview-server/package.json
@@ -59,7 +59,7 @@
     "tailwind-merge": "3.2.0",
     "tailwindcss": "3.4.0",
     "use-debounce": "10.0.4",
-    "zod": "3.24.3"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/babel__core": "7.20.5",


### PR DESCRIPTION
### Motivation
- Fumadocs tooling expects Zod v4 but `packages/preview-server` depended on Zod v3, which caused runtime resolution of the old major and produced `TypeError: z.looseObject is not a function` during `fumadocs-mdx` postinstall on Vercel.

### Description
- Updated `packages/preview-server/package.json` to use `zod` `^4.3.6` instead of `3.24.3` to align the workspace on Zod v4.

### Testing
- Validated by running `bun install` at the repo root (success) and `bun run postinstall` in `apps/docs` (`fumadocs-mdx` generated files successfully), while `bun run types:check` in `apps/docs` still fails due to pre-existing React type mismatches unrelated to this dependency bump.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ada34f57288321ae70cc66598ecd1f)